### PR TITLE
Please add a license

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2020 Michael Spengler
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.


### PR DESCRIPTION
Hi,

First of all, nice spinners library :)

I was just checking the licensing of the modules I am depending on for a deno script I'm working on, and I couldn't help but notice you don't currently specify a license for use of this module.

This legally means this repo is effectively "All rights reserved", which essentially means that no one besides yourself is allowed to do anything with it besides look at it. If that is your intention, please feel free to close this pull request!

However, I assume you intend this module to be usable by others. Considering that you give credit to an MIT-licensed codebase (and since most open source JavaScript/TypeScript tends to be MIT), I am suggesting the MIT license for this module, but of course if this is not to your taste feel free to pick another license.

Thanks!